### PR TITLE
Bugfix/6 allow multiple pr templates

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,7 +1,9 @@
-### What type of PR is this?
+# What type of PR is this?
 
-####  [feature](?expand=1&template=feature.md)
-####  [tests](?expand=1&template=tests.md)
-####  [docs](?expand=1&template=docs.md)
-####  [bugfix](?expand=1&template=bugfix.md)
-####  [hotfix](?expand=1&template=hotfix.md)
+<!-- switch to preview to select -->
+
+##  [feature](?expand=1&template=feature.md)
+##  [tests](?expand=1&template=tests.md)
+##  [docs](?expand=1&template=docs.md)
+##  [bugfix](?expand=1&template=bugfix.md)
+##  [hotfix](?expand=1&template=hotfix.md)

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,7 +1,7 @@
 ### What type of PR is this?
 
-####  [feature](?template=feature.md)
-####  [tests](?template=tests.md)
-####  [docs](?template=docs.md)
-####  [bugfix](?template=bugfix.md)
-####  [hotfix](?template=hotfix.md)
+####  [feature](?expand=1&template=feature.md)
+####  [tests](?expand=1&template=tests.md)
+####  [docs](?expand=1&template=docs.md)
+####  [bugfix](?expand=1&template=bugfix.md)
+####  [hotfix](?expand=1&template=hotfix.md)

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,7 @@
+### What type of PR is this?
+
+####  [feature](?template=feature.md)
+####  [tests](?template=tests.md)
+####  [docs](?template=docs.md)
+####  [bugfix](?template=bugfix.md)
+####  [hotfix](?template=hotfix.md)

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -82,7 +82,7 @@ Before opening a pull request, please make sure that:
 - New functionality includes tests where appropriate
 - Documentation is updated if behaviour changes
 
-When you have finalised your contribution, make a pull request (PR) into the ```develop``` branch. There will be templates available for each [contribution type](#TYPE). If your PR fixes, resolves, or closes an issue, please include the relevant keyword (e.g ```Closes #123```).
+When you have finalised your contribution, make a pull request (PR) into the `develop` branch. There will be templates available for each [contribution type](#TYPE). These templates can be accessed by switching to the preview view on the PR description and then clicking the approapriate option ([more on PR templates here](#pull-request-templates)). If your PR fixes, resolves, or closes an issue, please include the relevant keyword (e.g `Closes #123`) in the PR message.
 
 Resolve any comments left on the PR, and once it’s merged — enjoy the cred 🎉
 
@@ -125,3 +125,14 @@ The description should briefly summarise what the point of the work is. The ```D
 - readme_updates
 - skill_query_endpoint
 - agent_response_error_handling
+
+
+## Pull Request Templates
+
+Each [branch type](#type) has an associated PR template all of which can be found in [`.github/PULL_REQUEST_TEMPLATES`](../.github/PULL_REQUEST_TEMPLATE/). There are 3 ways of using these templates.
+
+1. When creating a PR, you will find a default PR message in the description. switching to the preview view will allow you to click on the options. Clicking on an option will open the template in the message editor.
+
+2. Add a query parameter to the URL for the branch comparison page of the form `?expand=1&template=<template_filename>`, for example `https://github.com/<org>/<repo>/compare/<branch>?expand=1&template=feature.md`. After adding this reload the new URL and the template should appear in the message editor.
+
+3. The other way to use a template is to simply copy and paste the raw markdown code from on of the template files. ⚠️ Note you should use the version of the template files on the `main` branch. 


### PR DESCRIPTION
<!-- .github/PULL_REQUEST_TEMPLATE/bugfix.md -->

# Bugfix:
Allow contributors to select from multiple PR templates

## Bug description
<!-- What was wrong? Include symptoms and impact. -->
- There is no standard way of selecting from multiple PR templates using the GitHub interface.
- This forces contributors into inelegant ways of populating the PR description editor with the markdown for the correct PR type.

## Root cause
<!-- What caused the bug? -->
- No standard solution offered by GitHub

## Fix summary
<!-- What did you change to fix it? -->
- Added a default PR template - `.github/pull_request_remplate.md` containing links to the templates.
- The are of the form `?expand=1&template=<template_name>` meaning the template will be automatically opened in the editor when the link is clicked.

## Reproduction steps
<!-- How to reproduce the bug on main? -->
N.A

## How to test the fix
<!-- Provide commands/steps to verify it’s fixed. -->
Steps:

  1. Make a dummy branch and then attempt to make a PR for it. Note that the templates are taken from the default branch and hence this issue will only be fully fixed when `develop` is merged into `main` following the merging of this PR.
  
## Related issues
Fixes #6 

## Checklist
- [] I added/updated tests where appropriate
- [x] I updated documentation if behaviour changed
